### PR TITLE
changed server port from 3001 to 4000 for backend 

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,7 +8,7 @@ import GameLobby from "./components/GameLobby";
 import GameRoom from "./components/GameRoom";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 
-const socket = io.connect("http://localhost:3001");
+const socket = io.connect("http://localhost:4000");
 
 function App() {
   // only used in GameLobby


### PR DESCRIPTION
## Description

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? -->

This redirects the port to 4000 instead of 3001 for app.js in backend, reducing the possibility of listening to the same port at the same time.

Now, npm run server is replaced by **npm start** on backend repo

## Related Issue

<!-- If you write "closes" followed by the Github issue number, it will automatically close the issue for you when the PR merges -->

## Acceptance Criteria

<!-- Include AC from the Github issue -->

## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
|  ✓   | :bug: Bug fix              |
|   | :sparkles: New feature     |
|    | :hammer: Refactoring       |
|    | :100: Add tests            |
|    | :link: Update dependencies |
|    | :scroll: Docs              |

## Updates

### Before

<!-- If UI feature, take provide screenshots -->

### After

<!-- If UI feature, take provide screenshots -->

## Testing Steps / QA Criteria

<!-- Provide steps the other team members and mentors need to follow to properly test your additions. -->
